### PR TITLE
Allow client to choose pagination

### DIFF
--- a/platalbank_django/settings.py
+++ b/platalbank_django/settings.py
@@ -116,7 +116,9 @@ REST_FRAMEWORK = {
     'DEFAULT_PERMISSION_CLASSES' :[
         'rest_framework.permissions.AllowAny', #TODO
     ],
-    'PAGE_SIZE': 20,
+    'PAGINATE_BY': 20,                 # Default to 20
+    'PAGINATE_BY_PARAM': 'page_size',  # Allow client to override, using `?page_size=xxx`.
+    'MAX_PAGINATE_BY': 100             # Maximum limit allowed when using `?page_size=xxx`.
 }
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
This is the same before, except that client can override number of
results per page.
A maximum limit is defined, though
